### PR TITLE
Update t_name.txt

### DIFF
--- a/t_name.txt
+++ b/t_name.txt
@@ -56,15 +56,15 @@
 
 //Germany<END>
 
-//Pass<END>
+//Tsunaki<END>
 
-//Interception<END>
+//Katsuto<END>
 
-//Draw<END>
+//Kinto<END>
 
-//Blocking<END>
+//Furoku<END>
 
-//Shoot<END>
+//Shuto<END>
 
 //Japan<END>
 


### PR DESCRIPTION
In the EU version, the 5 practice teams' names were put as their specialty (pass, interception, etc.), but those don't feel like names. IMO, their Japanese name sounds better (and also contain the puns on those skills). That's just my own opinion, so if you don't like it, it's okay.
